### PR TITLE
process: add undefined check for query of input()

### DIFF
--- a/lib/internal/bootstrap/switches/is_main_thread.js
+++ b/lib/internal/bootstrap/switches/is_main_thread.js
@@ -141,7 +141,7 @@ function getStderr() {
   return stderr;
 }
 
-function getStdin () {
+function getStdin() {
   if (stdin) return stdin;
   const fd = 0;
 
@@ -235,21 +235,23 @@ rawMethods.resetStdioForTesting = function() {
 };
 
 
-process.input = async function (...args) {
-  const utils = require("util")
-  const { createInterface } = require('readline')
+process.input = async function(...args) {
+  const util = require('util');
+  const { createInterface } = require('readline');
 
   const rl = createInterface({
     input: process.stdin,
     output: process.stdout
-  })
+  });
 
-  //If no argument is provided, the question is set to an empty string to avoid writing "undefined" to stdout
-  if(args[0] === undefined)
+  // if no args, set query to empty string
+  if (args[0] === undefined)
     args = '';
 
-  const res = await FunctionPrototypeApply(utils.promisify(rl.question), rl, args)
+  const question = util.promisify(rl.question);
+  
+  const res = await FunctionPrototypeApply(question, rl, args);
   // Close Readline to avoid process hang
-  rl.close()
-  return res
+  rl.close();
+  return res;
 }

--- a/lib/internal/bootstrap/switches/is_main_thread.js
+++ b/lib/internal/bootstrap/switches/is_main_thread.js
@@ -244,6 +244,10 @@ process.input = async function (...args) {
     output: process.stdout
   })
 
+  //If no argument is provided, the question is set to an empty string to avoid writing "undefined" to stdout
+  if(args[0] === undefined)
+    args = '';
+
   const res = await FunctionPrototypeApply(utils.promisify(rl.question), rl, args)
   // Close Readline to avoid process hang
   rl.close()

--- a/lib/internal/bootstrap/switches/is_main_thread.js
+++ b/lib/internal/bootstrap/switches/is_main_thread.js
@@ -244,14 +244,13 @@ process.input = async function(...args) {
     output: process.stdout
   });
 
-  // if no args, set query to empty string
+  // If no args, set query to empty string
   if (args[0] === undefined)
     args = '';
 
   const question = util.promisify(rl.question);
-  
   const res = await FunctionPrototypeApply(question, rl, args);
   // Close Readline to avoid process hang
   rl.close();
   return res;
-}
+};

--- a/test/pseudo-tty/test-process-input.js
+++ b/test/pseudo-tty/test-process-input.js
@@ -1,4 +1,4 @@
-'use strict'
+'use strict';
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/pseudo-tty/test-process-input.js
+++ b/test/pseudo-tty/test-process-input.js
@@ -1,6 +1,8 @@
-const common = require('../common')
-const assert = require('assert')
+'use strict'
+
+const common = require('../common');
+const assert = require('assert');
 
 process.input('question here').then(common.mustCall((res) => {
-  assert.strictEqual(res, "answer")
-}))
+  assert.strictEqual(res, 'answer');
+}));


### PR DESCRIPTION
<!--
Before submitting a pull request, please read
https://github.com/nodejs/node/blob/master/CONTRIBUTING.md.

Commit message formatting guidelines:
https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
Makes nodejs#37925 work as intended.

If `process.input` is called without any arguments, "undefined" is printed to `stdout` because the `query` parameter was `undefined` for `rl.question`. 

Adding a check to see if `args[0] === undefined` and setting it to an empty string if true fixes the issue.